### PR TITLE
Pin opencv-contrib-python to an older version. Add a module.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -69,7 +69,7 @@ dependencies:
     - git+git://github.com/slaclab/pyca
     - ipaddress
     - Cheetah3
-    - opencv-contrib-python
+    - opencv-contrib-python==4.2.0.34
 #
 # Stuff that isn't on PyPI or GitHub that is manually installed in prod
 # epics-batch-get

--- a/environment.yml
+++ b/environment.yml
@@ -58,6 +58,7 @@ dependencies:
   - pytables
   - tensorflow
   - theano
+  - treelib
   - pip:
     - git+git://github.com/slaclab/edmbutton
     - git+git://github.com/slaclab/edlgenerator


### PR DESCRIPTION
The newest version of openvc-contrib-python required C++ 11 features not available in rhel6. This pins it to a version that will work. Also adds treelib.