### PR TITLE
Relax the Python 3 pin to allow more recent versions of Bmad.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -44,7 +44,7 @@ dependencies:
   - pyqtgraph
   - pytao
   - pytest
-  - python=3.8.8
+  - python=3.8
   - pytorch
   - pytz
   - pyzmq

--- a/environment.yml
+++ b/environment.yml
@@ -60,14 +60,14 @@ dependencies:
   - theano
   - treelib
   - pip:
-    - git+git://github.com/slaclab/edmbutton
-    - git+git://github.com/slaclab/edlgenerator
-    - git+git://github.com/slaclab/slacepics
-    - git+git://github.com/slaclab/subprocessca
-    - git+git://github.com/slaclab/edef
+    - git+https://github.com/slaclab/edmbutton
+    - git+https://github.com/slaclab/edlgenerator
+    - git+https://github.com/slaclab/slacepics
+    - git+https://github.com/slaclab/subprocessca
+    - git+https://github.com/slaclab/edef
     - matlab-wrapper
-    - git+git://github.com/slaclab/meme
-    - git+git://github.com/slaclab/pyca
+    - git+https://github.com/slaclab/meme
+    - git+https://github.com/slaclab/pyca
     - ipaddress
     - Cheetah3
     - opencv-contrib-python==4.2.0.34


### PR DESCRIPTION
This changes the Python 3 pin from 3.8.8 to just 3.8, which lets the solver use more recent versions of Bmad.  The modules installed via pip from GitHub are also changed to use git+https, rather than git+git.