### PR TITLE
Add an action to publish a nightly build of the environment

### DIFF
--- a/.github/workflows/publish_nightly.yml
+++ b/.github/workflows/publish_nightly.yml
@@ -1,0 +1,24 @@
+name: Publish nightly release
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+
+jobs:
+  build:
+    env:
+      ENVIRONMENT_NAME: python3.8env
+      TEST_FILE: test.sh
+    runs-on: ubuntu-latest
+    name: Build environment
+    steps:
+      - name: Build environment
+        uses: slaclab/lcls-rhel6-conda-pack@v1.1
+      - name: Upload artifact to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.ENVIRONMENT_NAME }}.tar.gz
+          tag: nightly
+          overwrite: true
+          file_glob: true


### PR DESCRIPTION
As per request, create a nightly job for updating the python environment with the most recent possible versions of all packages.