### PR TITLE
Switch p4p from conda-forge to pypi

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,6 @@ dependencies:
   - numpy
   - openmpi
   - openpmd-beamphysics
-  - p4p
   - pandas
   - pip
   - pint
@@ -77,6 +76,7 @@ dependencies:
     - git+https://github.com/slaclab/lcls-tools
     - ipaddress
     - Cheetah3
+    - p4p
     - softioc
     - opencv-contrib-python==4.2.0.34
 #

--- a/environment.yml
+++ b/environment.yml
@@ -76,7 +76,7 @@ dependencies:
     - git+https://github.com/slaclab/lcls-tools
     - ipaddress
     - Cheetah3
-    - p4p
+    - p4p  # This is on conda-forge, but not updated. pypi has the latest versions
     - softioc
     - opencv-contrib-python==4.2.0.34
 #


### PR DESCRIPTION
The version uploaded to pypi is more recent, and this is listed as the preferred installation in the docs.