### PR TITLE
Temporarily remove opencv-contrib-python

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -93,7 +93,6 @@ dependencies:
     - ipaddress
     - Cheetah3
     - plex
-    - opencv-contrib-python==4.2.0.34
 #
 # Stuff that isn't on PyPI or GitHub that is manually installed in prod
 # epics-batch-get


### PR DESCRIPTION
Want to confirm this issue before fixing in a better way. Can add to post-build installation for now.