### PR TITLE
Specify the path to the file of the conda environment to create when running a job

### DIFF
--- a/.github/workflows/build_environment.yml
+++ b/.github/workflows/build_environment.yml
@@ -9,9 +9,10 @@ jobs:
   build:
     env:
       ENVIRONMENT_NAME: python3.8env
+      ENVIRONMENT_FILE_PATH: environment.yml
       TEST_FILE: test.sh
     runs-on: ubuntu-latest
     name: Build environment
     steps:
       - name: Build environment
-        uses: jbellister-slac/lcls-rhel6-conda-pack@e0c38e0d501ca34c5e33500e779ff28d13dd0d00
+        uses: jbellister-slac/lcls-rhel6-conda-pack@6b0b0a01c4c67cc0275ea7bedf9e9d51ae54c9c1

--- a/.github/workflows/publish_environment.yml
+++ b/.github/workflows/publish_environment.yml
@@ -9,12 +9,13 @@ jobs:
   build:
     env:
       ENVIRONMENT_NAME: python3.8env
+      ENVIRONMENT_FILE_PATH: environment.yml
       TEST_FILE: test.sh
     runs-on: ubuntu-latest
     name: Build environment
     steps:
       - name: Build environment
-        uses: jbellister-slac/lcls-rhel6-conda-pack@e0c38e0d501ca34c5e33500e779ff28d13dd0d00
+        uses: jbellister-slac/lcls-rhel6-conda-pack@6b0b0a01c4c67cc0275ea7bedf9e9d51ae54c9c1
       - name: Upload artifact to release
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/publish_nightly.yml
+++ b/.github/workflows/publish_nightly.yml
@@ -8,12 +8,13 @@ jobs:
   build:
     env:
       ENVIRONMENT_NAME: python3.8env
+      ENVIRONMENT_FILE_PATH: nightly-environment.yml
       TEST_FILE: test.sh
     runs-on: ubuntu-latest
     name: Build environment
     steps:
       - name: Build environment
-        uses: jbellister-slac/lcls-rhel6-conda-pack@e0c38e0d501ca34c5e33500e779ff28d13dd0d00
+        uses: jbellister-slac/lcls-rhel6-conda-pack@6b0b0a01c4c67cc0275ea7bedf9e9d51ae54c9c1
       - name: Upload artifact to release
         uses: svenstaro/upload-release-action@v2
         with:

--- a/nightly-environment.yml
+++ b/nightly-environment.yml
@@ -47,7 +47,6 @@ dependencies:
   - numpy
   - openmpi
   - openpmd-beamphysics
-  - p4p>=3.5.5
   - pandas
   - pip
   - pint
@@ -92,7 +91,7 @@ dependencies:
     - git+https://github.com/slaclab/mps_history
     - ipaddress
     - Cheetah3
-    - plex
+    - p4p
     - opencv-contrib-python==4.2.0.34
 #
 # Stuff that isn't on PyPI or GitHub that is manually installed in prod


### PR DESCRIPTION
Mostly prep work for dropping a rhel7 python 3.9 environment in here. At which point the repo should probably be renamed and restructured a bit. Will stop using hashes for the action when I get write permissions there.