### PR TITLE
Add matlabengine to the default environment

### DIFF
--- a/default-rhel6-environment.yml
+++ b/default-rhel6-environment.yml
@@ -85,6 +85,7 @@ dependencies:
     - git+https://github.com/slaclab/slacepics
     - git+https://github.com/slaclab/subprocessca
     - git+https://github.com/slaclab/edef
+    - matlabengine==9.13.7
     - matlab-wrapper
     - git+https://github.com/slaclab/meme
     - git+https://github.com/slaclab/pyca


### PR DESCRIPTION
Now that matlab 2022b is available on RHEL 7 machines, see if matlabengine can be added without any issues. Putting it into the default RHEL 6 environment to start since it can still be sourced from RHEL 7 machines without issue. There's also no backwards compatibility issue here since there is no matlabengine that runs on both 2020a and python 3.8

https://www.mathworks.com/support/requirements/python-compatibility.html