### PR TITLE
Revert "Add matlabengine to the default environment"

### DIFF
--- a/default-rhel6-environment.yml
+++ b/default-rhel6-environment.yml
@@ -85,7 +85,6 @@ dependencies:
     - git+https://github.com/slaclab/slacepics
     - git+https://github.com/slaclab/subprocessca
     - git+https://github.com/slaclab/edef
-    - matlabengine==9.13.7
     - matlab-wrapper
     - git+https://github.com/slaclab/meme
     - git+https://github.com/slaclab/pyca


### PR DESCRIPTION
It requires a matlab installation to build against. Which could certainly be added to the docker image, but then it doesn't build on RHEL 6 anyway. So will move to the install manually list after other issues are resolved and leave there while RHEL 6 support is necessary