### PR TITLE
ENH: Add xopt test run, add pyemittance

### DIFF
--- a/default-rhel7-environment.yml
+++ b/default-rhel7-environment.yml
@@ -98,6 +98,8 @@ dependencies:
     - git+https://github.com/slaclab/mps_history
     - git+https://github.com/ChristopherMayes/Xopt
     - git+https://github.com/dylanmkennedy/emitopt
+    - jax>=0.4.16
+    - jaxlib>=0.4.16
     - ipaddress
     - Cheetah3
     - p4p

--- a/default-rhel7-environment.yml
+++ b/default-rhel7-environment.yml
@@ -56,7 +56,7 @@ dependencies:
   - pcaspy
   - pip
   - pint
-  - pydantic
+  - pydantic>=2.3
   - pydm
   - pyepics
   - pyqt

--- a/default-rhel7-environment.yml
+++ b/default-rhel7-environment.yml
@@ -56,7 +56,7 @@ dependencies:
   - pcaspy
   - pip
   - pint
-  - pydantic=1.10.9
+  - pydantic
   - pydm
   - pyepics
   - pyqt

--- a/nightly-rhel7-environment.yml
+++ b/nightly-rhel7-environment.yml
@@ -97,6 +97,7 @@ dependencies:
     - git+https://github.com/ChristopherMayes/Xopt
     - git+https://github.com/dylanmkennedy/emitopt
     - git+https://github.com/slaclab/Badger.git
+    - git+https://github.com/slaclab/PyEmittance
     - ipaddress
     - Cheetah3
     - p4p

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+conda remove --force --offline --yes jax
+conda remove --force --offline --yes jaxlib
+
 git clone https://github.com/ChristopherMayes/Xopt.git
 cd Xopt
 pytest

--- a/test.sh
+++ b/test.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
+
+# Temporary fix for a jax incompatibility, can be removed once that is resolved
 conda remove --force --offline --yes jax
 conda remove --force --offline --yes jaxlib
-
 pip install jax==0.4.16
 pip install jaxlib==0.4.19
 pip install jaxtyping==0.2.21
 
+# All tests to be run to verify the environment built correctly and will work as expected at run time
 git clone https://github.com/ChristopherMayes/Xopt.git
 cd Xopt
 pytest

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,10 @@
 conda remove --force --offline --yes jax
 conda remove --force --offline --yes jaxlib
 
+pip install jax==0.4.16
+pip install jaxlib==0.4.19
+pip install jaxtyping==0.2.21
+
 git clone https://github.com/ChristopherMayes/Xopt.git
 cd Xopt
 pytest


### PR DESCRIPTION
Adds a run of the xopt test suite to the testing script, environment will not be pushed if it fails.

Also adds pyemittance to the nightly environment.